### PR TITLE
chore: bump fbx to 0.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY setup.py .
 RUN echo "Installing requirements..."
 RUN pip install --quiet --upgrade pip setuptools wheel &&  \
     pip install -e . && \
-    pip install flashbax==0.1.0
+    pip install flashbax==0.1.1
 
 # ENV SC2PATH /home/app/StarCraftII
 # RUN ./install_environments/smacv1.sh

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Install `og-marl` and its dependencies. We tested `og-marl` with Python 3.9. Con
 
 `pip install -e .`
 
-`pip install flashbax==0.1.0`
+`pip install flashbax==0.1.1`
 
 Download environment dependencies. We will use SMACv1 in this example.
 

--- a/examples/dataset_api_demo.ipynb
+++ b/examples/dataset_api_demo.ipynb
@@ -89,7 +89,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "! pip install flashbax~=0.1.0\n",
+        "! pip install flashbax~=0.1.1\n",
         "\n",
         "import jax\n",
         "import jax.numpy as jnp\n",

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setup(
         "jax[cpu]==0.4.20",
         "matplotlib",
         "seaborn",
-        # "flashbax==0.1.0", # install post
+        # "flashbax==0.1.1", # install post
     ],
     extras_require={
-        "jax": ["flashbax", "optax", "jax", "flax", "orbax-checkpoint"],
+        "jax": ["flashbax==0.1.1", "optax", "jax", "flax", "orbax-checkpoint"],
     },
 )


### PR DESCRIPTION
Use latest fbx release, which includes:
- vault compression
- correct `current_index` when reading